### PR TITLE
図書館情報をpostの詳細に表示#169

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,6 +42,12 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
+
+    @library = current_user.library
+    if @library.present?
+      gon.library = @library.name
+    end
+    gon.book = @post
   end
 
   def edit; end

--- a/app/javascript/packs/calil.js
+++ b/app/javascript/packs/calil.js
@@ -35,7 +35,7 @@ function promiseFactory(count) {
               if (Object.keys(situation).length === 0 && situation.constructor === Object) {
                   $("#search").remove();
                   $("#choice").prepend(`<h4>
-                  <button type="button" class="badge bg-secondary btn-block">図書館に本がありません</button>
+                  <button type="button" class="badge bg-secondary">図書館に本がありません</button>
                   </h4>`)
                   clearTimeout( timer_id );
               } else {
@@ -46,17 +46,17 @@ function promiseFactory(count) {
                   //choiceにvalue（図書館名）、this[value](貸出情報)を出力
                   if (this[value] === "貸出可") {
                     $("#choice").prepend(`<h4>
-                    <span class="badge bg-success btn-block">${value} : ${this[value]}</span>
+                    <button type="button" class="badge bg-outline text-info">${value} : ${this[value]}</button>
                     </h4>`)
                   } else {
 
                   $("#choice").prepend(`<h4>
-                  <span class="badge bg-info btn-block">${value} : ${this[value]}</span>
+                  <button type="button" class="badge bg-outline">${value} : ${this[value]}</button>
                   </h4>`)
                   }
                 }, situation)
                 $("#choice2").prepend(`<h4>
-                  <button type="button" class="badge bg-outline-info btn-block reserve"><a href="${reserveurl}">予約する</a></button>
+                  <button type="button" class="badge"><a href="${reserveurl}">予約する</a></button>
                   </h4>`)
                 //data.continueが0だった場合にループ（setTimeout）を抜ける
                 clearTimeout( timer_id );

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -65,6 +65,40 @@
       </div>
     </div>
   </article>
+
+  <% if @library.present? %>
+  <div class="low text-center">
+    <article class="card mb-3">
+      <div class="card-body">
+          <div class='col'>
+            <h5><%= @library.display.present? ? "#{@library.display} 図書館状況" : "#{@library.name} 図書館状況" %></h5>
+            <% if @post.systemid.present?%>
+              <p><div id="search"><i class="fa fa-spinner fa-spin fa-4x fa-fw" style="color: orange"></i></div></p>
+              <p id="choice"></p>
+              <p id="choice2"></p>
+              <%= javascript_pack_tag "calil" %>
+            <% else %>
+              <button type="button" class="btn btn-dark">検索できません<p>Googleに本NOの登録がありませんでした</button>
+            <% end %>
+          </div>
+      </div>
+    </article>
+  </div>
+<% else %>
+ <div class="low text-center">
+    <%= link_to '図書館登録をすると貸出状況が表示されます', libraries_path, class: "btn bg-danger text-white m-3" %> 
+  </div>
+<% end %>
+
+
+
+
+
+
+
+
+
+
   <p>
     <% if logged_in? %>
       <%= render 'comments/form', { post: @post, comment: @comment } %>

--- a/spec/system/books/book_spec.rb
+++ b/spec/system/books/book_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Books', type: :system do
           expect(page).to have_content 'よみたいリストに登録しました'
         end
 
-        it '検索した本の詳細を選択すると図書館情報が表示される' do
+        it '検索した本の詳細を選択すると図書館情報が表示される(はらぺこあおむし)' do
           visit search_books_path
           fill_in 'search', with: 'はらぺこあおむし'
           click_button '検索'
@@ -66,6 +66,36 @@ RSpec.describe 'Books', type: :system do
           visit book_path(1)
           sleep 5
           expect(page).to have_content '予約する'
+        end
+
+        it '検索した本の詳細を選択すると図書館情報が表示される(くまくまパン)' do
+          visit search_books_path
+          fill_in 'search', with: 'くまくまパン'
+          click_button '検索'
+          first('#new_book').click
+          visit book_path(1)
+          sleep 5
+          expect(page).to have_content '予約する'
+        end
+
+        it '検索した本の詳細を選択すると図書館情報が表示される（図書館に本がありません）' do
+          visit search_books_path
+          fill_in 'search', with: '実践Rails'
+          click_button '検索'
+          first('#new_book').click
+          visit book_path(1)
+          sleep 5
+          expect(page).to have_content '図書館に本がありません'
+        end
+
+        it '検索した本の詳細を選択すると図書館情報が表示されない（ISBN無し）' do
+          visit search_books_path
+          fill_in 'search', with: 'おおかみと7ひきのこやぎ'
+          click_button '検索'
+          first('#new_book').click
+          visit book_path(1)
+          sleep 5
+          expect(page).to have_content '検索できません'
         end
 
         it '本の詳細が表示される' do

--- a/spec/system/posts/post_spec.rb
+++ b/spec/system/posts/post_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Posts', type: :system do
     let(:age) { create(:age) }
     let(:category) { create(:category) }
     let(:category_b) { create(:category_2) }
+    let(:library) { create(:library, user: me) }
 
       describe 'レビューリスト' do
         context 'ログインしていない場合' do
@@ -59,6 +60,7 @@ RSpec.describe 'Posts', type: :system do
             login_as(me)
             category
             age
+            library
           end
 
           it '検索した本を新規追加できる（カテゴリー1、年齢1）' do
@@ -130,6 +132,66 @@ RSpec.describe 'Posts', type: :system do
             expect(page).to have_content post.published_date
             expect(page).to have_content author.name
             expect(page).to have_link 'Google', href: post.info_link
+          end
+          
+          it '検索した本の詳細を選択すると図書館情報が表示される(はらぺこあおむし）' do
+            visit search_books_path
+            fill_in 'search', with: 'はらぺこあおむし'
+            click_button '検索'
+            first(".review").click
+            expect(current_path).to eq new_post_path
+            fill_in 'post_body', with: 'レビューした内容'
+            expect { click_button '登録する' }.to change { Post.count }.by(1)
+            expect(current_path).to eq posts_path
+            expect(page).to have_content 'レビューを投稿しました'
+            visit post_path(1)
+            sleep 5
+            expect(page).to have_content '予約する'
+          end
+
+          it '検索した本の詳細を選択すると図書館情報が表示される(くまくまパン)' do
+            visit search_books_path
+            fill_in 'search', with: 'くまくまパン'
+            click_button '検索'
+            first(".review").click
+            expect(current_path).to eq new_post_path
+            fill_in 'post_body', with: 'レビューした内容'
+            expect { click_button '登録する' }.to change { Post.count }.by(1)
+            expect(current_path).to eq posts_path
+            expect(page).to have_content 'レビューを投稿しました'
+            visit post_path(1)
+            sleep 5
+            expect(page).to have_content '予約する'
+          end
+
+          it '検索した本の詳細を選択すると図書館情報が表示される(図書館に書籍がないケース)' do
+            visit search_books_path
+            fill_in 'search', with: '実践Rails'
+            click_button '検索'
+            first(".review").click
+            expect(current_path).to eq new_post_path
+            fill_in 'post_body', with: 'レビューした内容'
+            expect { click_button '登録する' }.to change { Post.count }.by(1)
+            expect(current_path).to eq posts_path
+            expect(page).to have_content 'レビューを投稿しました'
+            visit post_path(1)
+            sleep 5
+            expect(page).to have_content '図書館に本がありません'
+          end
+
+          it '検索した本の詳細を選択すると図書館情報が表示される(ISBN無し)' do
+            visit search_books_path
+            fill_in 'search', with: 'おおかみと7ひきのこやぎ'
+            click_button '検索'
+            first(".review").click
+            expect(current_path).to eq new_post_path
+            fill_in 'post_body', with: 'レビューした内容'
+            expect { click_button '登録する' }.to change { Post.count }.by(1)
+            expect(current_path).to eq posts_path
+            expect(page).to have_content 'レビューを投稿しました'
+            visit post_path(1)
+            sleep 5
+            expect(page).to have_content '検索できません'
           end
 
           it '本の詳細から年齢で絞りこむ' do


### PR DESCRIPTION
図書館の貸出情報は今までbook_showのみの表示だったが、post_showにも表示するよう改修します。